### PR TITLE
CMS: Add flag to override time limit

### DIFF
--- a/pisek/__main__.py
+++ b/pisek/__main__.py
@@ -81,12 +81,19 @@ def main(argv):
         )
     )
 
-    def add_argument_description(parser):
+    def add_cms_import_arguments(parser):
         parser.add_argument(
             "--description",
             "-d",
             type=str,
             help="create the dataset with the description DESCRIPTION",
+        )
+
+        parser.add_argument(
+            "--time-limit",
+            "-t",
+            type=float,
+            help="override the time limit when importing to TIME_LIMIT seconds",
         )
 
     def add_argument_dataset(parser):
@@ -279,7 +286,7 @@ def main(argv):
     )
 
     parser_cms_create = subparsers_cms.add_parser("create", help="create a new task")
-    add_argument_description(parser_cms_create)
+    add_cms_import_arguments(parser_cms_create)
 
     parser_cms_update = subparsers_cms.add_parser(
         "update", help="update the basic properties of an existing task"
@@ -288,7 +295,7 @@ def main(argv):
     parser_cms_add = subparsers_cms.add_parser(
         "add", help="add a dataset to an existing task"
     )
-    add_argument_description(parser_cms_add)
+    add_cms_import_arguments(parser_cms_add)
     parser_cms_add.add_argument(
         "--no-autojudge",
         action="store_true",

--- a/pisek/cms/__init__.py
+++ b/pisek/cms/__init__.py
@@ -89,8 +89,9 @@ def create(env: Env, args: Namespace) -> int:
     session = Session()
 
     description = args.description
+    time_limit = args.time_limit
 
-    task = create_task(session, env, testcases, description)
+    task = create_task(session, env, testcases, description, time_limit)
     dataset = task.active_dataset
 
     try:
@@ -127,10 +128,13 @@ def add(env: Env, args: Namespace) -> int:
     session = Session()
 
     description = args.description
+    time_limit = args.time_limit
     autojudge = not args.no_autojudge
 
     task = get_task(session, env.config)
-    dataset = create_dataset(session, env, task, testcases, description, autojudge)
+    dataset = create_dataset(
+        session, env, task, testcases, description, time_limit, autojudge
+    )
 
     try:
         session.commit()

--- a/pisek/cms/dataset.py
+++ b/pisek/cms/dataset.py
@@ -32,6 +32,7 @@ def create_dataset(
     task: Task,
     testcases: list[InputPath],
     description: Optional[str],
+    time_limit: Optional[float],
     autojudge: bool = True,
 ) -> Dataset:
     if description is None:
@@ -64,7 +65,7 @@ def create_dataset(
         task_type_parameters=task_params,
         score_type="GroupMin",
         score_type_parameters=score_params,
-        time_limit=config.cms.time_limit,
+        time_limit=time_limit if time_limit is not None else config.cms.time_limit,
         memory_limit=config.cms.mem_limit * 1024 * 1024,
         task=task,
     )

--- a/pisek/cms/task.py
+++ b/pisek/cms/task.py
@@ -11,6 +11,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from datetime import timedelta
+from typing import Optional
 from cms.db.task import Task
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
@@ -22,14 +23,18 @@ from pisek.utils.paths import InputPath
 
 
 def create_task(
-    session: Session, env: Env, testcases: list[InputPath], description: str
+    session: Session,
+    env: Env,
+    testcases: list[InputPath],
+    description: str,
+    time_limit: Optional[float],
 ) -> Task:
     config = env.config
 
     task = Task(name=config.cms.name, title=config.cms.title)
     set_task_settings(task, config)
 
-    dataset = create_dataset(session, env, task, testcases, description)
+    dataset = create_dataset(session, env, task, testcases, description, time_limit)
 
     task.active_dataset = dataset
 


### PR DESCRIPTION
This PR allows for setting the time limit when importing with a flag:

```
pisek cms create -t 10
```
