### PR TITLE
fix(solution): Fix missing correct solution when judge_needs_out=0 and -C

### DIFF
--- a/pisek/task_jobs/solution/manager.py
+++ b/pisek/task_jobs/solution/manager.py
@@ -197,7 +197,11 @@ class SolutionManager(TaskJobManager, TestcaseInfoMixin):
             input_path,
             out,
             testcase_info.reference_output(
-                self._env, seed, solution=self.solution_label
+                self._env,
+                seed,
+                solution=(
+                    self.solution_label if self._env.config.judge_needs_out else None
+                ),
             ),
             test,
             seed,


### PR DESCRIPTION
When running with `judge_needs_out=0`, `-C` and solution doesn't result as expected, pisek crashes:
```
[...]
  File "/home/skipy/dev/pisek/pisek/task_jobs/solution/manager.py", line 497, in as_expected
    msg += f"\n{tab(breaker.message())}"
                    ~~~~~~~~~~~~~~~^^
  File "/home/skipy/dev/pisek/pisek/task_jobs/checker/checker_base.py", line 116, in message
    text += f"correct output: {self._quote_file_with_name(self.correct_output)}"
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/home/skipy/dev/pisek/pisek/task_jobs/task_job.py", line 252, in _quote_file_with_name
    return f"{file.col(self._env)}\n{self._colored(tab(self._quote_file(file, **kwargs)), 'yellow')}\n"
                                                       ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/skipy/dev/pisek/pisek/task_jobs/task_job.py", line 241, in _quote_file
    with self._open_file(file) as f:
         ~~~~~~~~~~~~~~~^^^^^^
  File "/home/skipy/dev/pisek/pisek/task_jobs/task_job.py", line 132, in g
    return f(self, *args, **kwargs)
  File "/home/skipy/dev/pisek/pisek/task_jobs/task_job.py", line 142, in _open_file
    return open(filename.path, mode, **kwargs)
FileNotFoundError: [Errno 2] No such file or directory: 'tests/solve_py/sample.ok'
```