### PR TITLE
refactor: ProgramType -> ProgramRole

### DIFF
--- a/docs/config-v3-documentation
+++ b/docs/config-v3-documentation
@@ -287,13 +287,13 @@ tests=@auto
 
 build=@auto
 # Reference to the build section specifying how to build this program
-# @auto expands to '{program_type}:{subdir}/{program}', e.g. 'solution:solutions/solve' (default)
+# @auto expands to '{program_role}:{subdir}/{program}', e.g. 'solution:solutions/solve' (default)
 # See [build] for more
 
 exec=@auto
 # Filename of the program to execute (without suffix)
 # If a directory is chosen directory/run is executed instead
-# @auto expands to the value of the build key without '{program_type}:' (default)
+# @auto expands to the value of the build key without '{program_role}:' (default)
 args=--slow
 # Additional arguments for the program. (Given before any other arguments.)
 # (defaults to empty)

--- a/pisek/config/config_types.py
+++ b/pisek/config/config_types.py
@@ -76,7 +76,7 @@ def validate_test_points(points: str):
 TestPoints = Annotated[int | Literal["unscored"], BeforeValidator(validate_test_points)]
 
 
-class ProgramType(StrEnum):
+class ProgramRole(StrEnum):
     gen = auto()
     validator = auto()
     primary_solution = auto()
@@ -84,7 +84,7 @@ class ProgramType(StrEnum):
     judge = auto()
 
     def is_solution(self) -> bool:
-        return self in (ProgramType.primary_solution, ProgramType.secondary_solution)
+        return self in (ProgramRole.primary_solution, ProgramRole.secondary_solution)
 
     @property
     def build_name(self) -> str:

--- a/pisek/config/update_config.py
+++ b/pisek/config/update_config.py
@@ -20,7 +20,7 @@ import re
 from pisek.utils.text import eprint
 from pisek.utils.colors import ColorSettings
 from pisek.config.config_errors import TaskConfigError
-from pisek.config.config_types import ProgramType
+from pisek.config.config_types import ProgramRole
 
 
 def maybe_rename_key(
@@ -212,33 +212,33 @@ def update_to_v3(config: ConfigParser, task_path: str) -> None:
     maybe_rename_key(config, "tests", "tests", "checker", "validator")
 
     OLD_NAME = {
-        ProgramType.gen: "in_gen",
-        ProgramType.validator: "checker",
-        ProgramType.primary_solution: "solve",
-        ProgramType.secondary_solution: "sec_solve",
-        ProgramType.judge: "judge",
+        ProgramRole.gen: "in_gen",
+        ProgramRole.validator: "checker",
+        ProgramRole.primary_solution: "solve",
+        ProgramRole.secondary_solution: "sec_solve",
+        ProgramRole.judge: "judge",
     }
 
-    for new_program_type in ProgramType:
-        old_program_type = OLD_NAME[new_program_type]
-        if new_program_type == ProgramType.primary_solution:
+    for new_program_role in ProgramRole:
+        old_program_role = OLD_NAME[new_program_role]
+        if new_program_role == ProgramRole.primary_solution:
             section = "run_solution"
         else:
-            section = f"run_{new_program_type}"
+            section = f"run_{new_program_role}"
 
         config.add_section(section)
         config[section]["clock_mul"] = "0"
         config[section]["clock_min"] = config.get(
-            "limits", f"{old_program_type}_clock_limit", fallback="360"
+            "limits", f"{old_program_role}_clock_limit", fallback="360"
         )
-        maybe_delete_key(config, "limits", f"{old_program_type}_clock_limit")
+        maybe_delete_key(config, "limits", f"{old_program_role}_clock_limit")
 
         for limit in ("time", "mem", "process"):
             maybe_rename_key(
                 config,
                 "limits",
                 section,
-                f"{old_program_type}_{limit}_limit",
+                f"{old_program_role}_{limit}_limit",
                 f"{limit}_limit",
             )
 

--- a/pisek/task_jobs/checker/cms_judge.py
+++ b/pisek/task_jobs/checker/cms_judge.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 from pisek.utils.paths import InputPath, OutputPath
 from pisek.env.env import Env
 from pisek.config.task_config import RunSection
-from pisek.config.config_types import ProgramType
+from pisek.config.config_types import ProgramRole
 from pisek.task_jobs.run_result import RunResult
 from pisek.task_jobs.solution.solution_result import (
     Verdict,
@@ -120,7 +120,7 @@ class RunCMSBatchJudge(RunCMSJudge, RunBatchChecker):
             self._access_file(self.correct_output)
 
         result = self._run_program(
-            ProgramType.judge,
+            ProgramRole.judge,
             self.judge,
             args=[
                 (

--- a/pisek/task_jobs/checker/opendata_judge.py
+++ b/pisek/task_jobs/checker/opendata_judge.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from pisek.utils.paths import InputPath, OutputPath
 from pisek.env.env import Env
-from pisek.config.config_types import ProgramType
+from pisek.config.config_types import ProgramRole
 from pisek.config.task_config import RunSection
 from pisek.task_jobs.solution.solution_result import (
     Verdict,
@@ -137,7 +137,7 @@ class RunOpendataJudge(RunBatchChecker):
             self._access_file(self.correct_output)
 
         self._result = self._run_program(
-            ProgramType.judge,
+            ProgramRole.judge,
             self.judge,
             args=[
                 str(self.test),

--- a/pisek/task_jobs/generator/cms_old.py
+++ b/pisek/task_jobs/generator/cms_old.py
@@ -14,7 +14,7 @@ import os
 import shutil
 
 from pisek.env.env import Env
-from pisek.config.config_types import ProgramType
+from pisek.config.config_types import ProgramRole
 from pisek.config.task_config import RunSection
 from pisek.utils.paths import TaskPath, LogPath
 from pisek.task_jobs.program import RunResultKind
@@ -39,7 +39,7 @@ class CmsOldListInputs(GeneratorListInputs):
         self.makedirs(gen_dir, exist_ok=False)
 
         run_result = self._run_program(
-            ProgramType.gen,
+            ProgramRole.gen,
             self.generator,
             args=[gen_dir.abspath],
             stderr=LogPath.generator_log(self.generator.name),

--- a/pisek/task_jobs/generator/opendata_v1.py
+++ b/pisek/task_jobs/generator/opendata_v1.py
@@ -13,7 +13,7 @@
 from typing import Optional
 
 from pisek.env.env import Env
-from pisek.config.config_types import ProgramType
+from pisek.config.config_types import ProgramRole
 from pisek.config.task_config import RunSection
 from pisek.utils.paths import InputPath
 from pisek.task_jobs.program import ProgramsJob, RunResultKind
@@ -55,7 +55,7 @@ class OpendataV1GeneratorJob(ProgramsJob):
         test = int(self.testcase_info.name)
 
         result = self._run_program(
-            ProgramType.gen,
+            ProgramRole.gen,
             self.generator,
             args=[str(test), f"{self.seed:016x}"],
             stdout=self.input_path.to_raw(self._env.config.tests.in_format),

--- a/pisek/task_jobs/generator/pisek_v1.py
+++ b/pisek/task_jobs/generator/pisek_v1.py
@@ -15,7 +15,7 @@ from typing import Any, NoReturn, Optional
 
 from pisek.utils.text import tab
 from pisek.env.env import Env
-from pisek.config.config_types import ProgramType
+from pisek.config.config_types import ProgramRole
 from pisek.config.task_config import RunSection
 from pisek.utils.paths import TaskPath, InputPath, LogPath
 from pisek.task_jobs.program import ProgramsJob, RunResultKind
@@ -101,7 +101,7 @@ class PisekV1ListInputs(GeneratorListInputs):
 
     def _create_inputs_list(self) -> None:
         self._run_result = self._run_program(
-            ProgramType.gen,
+            ProgramRole.gen,
             self.generator,
             stdout=self._get_inputs_list_path(),
             stderr=LogPath.generator_log(self.generator.name),
@@ -141,7 +141,7 @@ class PisekV1GeneratorJob(ProgramsJob):
             args.append(f"{self.seed:016x}")
 
         result = self._run_program(
-            ProgramType.gen,
+            ProgramRole.gen,
             self.generator,
             args=args,
             stdout=self.input_path.to_raw(self._env.config.tests.in_format),

--- a/pisek/task_jobs/program.py
+++ b/pisek/task_jobs/program.py
@@ -22,7 +22,7 @@ from typing import Optional, Any, Union, Callable
 import signal
 import subprocess
 
-from pisek.config.task_config import ProgramType, RunSection
+from pisek.config.task_config import ProgramRole, RunSection
 from pisek.env.env import Env
 from pisek.utils.paths import TaskPath, LogPath
 from pisek.jobs.jobs import PipelineItemFailure
@@ -142,7 +142,7 @@ class ProgramsJob(TaskJob):
 
     def _load_program(
         self,
-        program_type: ProgramType,
+        program_role: ProgramRole,
         program: RunSection,
         args: list[str] = [],
         stdin: Optional[Union[TaskPath, int]] = None,
@@ -152,7 +152,7 @@ class ProgramsJob(TaskJob):
     ) -> None:
         """Adds program to execution pool."""
         time_limit: Optional[float] = None
-        if program_type.is_solution():
+        if program_role.is_solution():
             time_limit = self._env.time_limit
 
         self._load_executable(
@@ -279,12 +279,12 @@ class ProgramsJob(TaskJob):
 
     def _run_program(
         self,
-        program_type: ProgramType,
+        program_role: ProgramRole,
         program: RunSection,
         **kwargs,
     ) -> RunResult:
         """Loads one program and runs it."""
-        self._load_program(program_type, program, **kwargs)
+        self._load_program(program_role, program, **kwargs)
         return self._run_programs()[0]
 
     def _run_tool(

--- a/pisek/task_jobs/solution/solution.py
+++ b/pisek/task_jobs/solution/solution.py
@@ -18,7 +18,7 @@ from typing import Optional
 
 from pisek.env.env import Env
 from pisek.utils.paths import InputPath
-from pisek.config.config_types import ProgramType
+from pisek.config.config_types import ProgramRole
 from pisek.config.task_config import RunSection
 from pisek.task_jobs.program import RunResult, ProgramsJob
 from pisek.task_jobs.solution.solution_result import Verdict, SolutionResult
@@ -50,11 +50,11 @@ class RunSolution(ProgramsJob):
             self.cancel()
         assert self._needed_by >= 0
 
-    def _solution_type(self) -> ProgramType:
+    def _solution_type(self) -> ProgramRole:
         return (
-            (ProgramType.primary_solution)
+            (ProgramRole.primary_solution)
             if self.is_primary
-            else (ProgramType.secondary_solution)
+            else (ProgramRole.secondary_solution)
         )
 
 
@@ -80,7 +80,7 @@ class RunBatchSolution(RunSolution):
 
     def _run(self) -> RunResult:
         return self._run_program(
-            program_type=self._solution_type(),
+            program_role=self._solution_type(),
             program=self.solution,
             stdin=self.input,
             stdout=self.output,
@@ -131,7 +131,7 @@ class RunInteractive(RunCMSJudge, RunSolution):
             ]
 
             self._load_program(
-                ProgramType.judge,
+                ProgramRole.judge,
                 self.judge,
                 stdin=self.input,
                 stdout=self.points_file,

--- a/pisek/task_jobs/validator/validator_base.py
+++ b/pisek/task_jobs/validator/validator_base.py
@@ -14,7 +14,7 @@ from abc import abstractmethod
 
 from pisek.env.env import Env
 from pisek.utils.paths import InputPath
-from pisek.config.task_config import ProgramType, RunSection
+from pisek.config.task_config import ProgramRole, RunSection
 from pisek.task_jobs.run_result import RunResult
 from pisek.task_jobs.program import ProgramsJob
 
@@ -47,7 +47,7 @@ class ValidatorJob(ProgramsJob):
 
     def _validate(self) -> RunResult:
         return self._run_program(
-            ProgramType.validator,
+            ProgramRole.validator,
             self.validator,
             args=self._validation_args(),
             stdin=self.input,


### PR DESCRIPTION
Changes `ProgramType` to `ProgramRole`. Reasons for this change:
- type -> `(gen|validator|judge)_type`, role -> `ProgramRole`
- Also programs can have multiple roles