### PR TITLE
fix(config): Allow `stubs` key in `[cms]` section

### DIFF
--- a/pisek/config/config-description
+++ b/pisek/config/config-description
@@ -424,5 +424,5 @@ min_submission_interval=
 score_mode=
 feedback_level=
 
-stub=
+stubs=
 headers=


### PR DESCRIPTION
Fixes #493 