### PR TITLE
Refactor `ColorSettings` Singleton to `camelCase`

### DIFF
--- a/pisek/__main__.py
+++ b/pisek/__main__.py
@@ -33,7 +33,7 @@ from pisek.user_errors import (
 
 from pisek.utils.util import clean_task_dir, log_level_mapper
 from pisek.utils.text import eprint
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 
 from pisek.visualize import visualize
 from pisek.init import init_task
@@ -349,7 +349,7 @@ def _main(argv: list[str]) -> None:
 
     if args.pisek_dir is None and "PISEK_DIRECTORY" in os.environ:
         args.pisek_dir = os.path.join(os.getcwd(), os.environ["PISEK_DIRECTORY"])
-    colorSettings.set_state(not args.plain and not args.no_colors)
+    color_settings.set_state(not args.plain and not args.no_colors)
 
     # Taskless subcommands
     if args.subcommand == "version":
@@ -441,7 +441,7 @@ def main(argv: list[str]) -> int:
     except TestingFailed:
         return 1
     except (TaskConfigError, MissingFile, InvalidArgument, InvalidOperation) as e:
-        print(colorSettings.colored(str(e), "red"))
+        print(color_settings.colored(str(e), "red"))
         return 2
     except UserError:
         raise NotImplementedError()

--- a/pisek/cms/result.py
+++ b/pisek/cms/result.py
@@ -19,7 +19,7 @@ import json
 
 from pisek.user_errors import TestingFailed
 from pisek.cms.submission import get_submission
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.env.env import Env
 from pisek.task_jobs.testing_log import TESTING_LOG
 from pisek.task_jobs.solution.solution_result import Verdict
@@ -52,7 +52,7 @@ def create_testing_log(session: Session, env: Env, dataset: Dataset) -> None:
         try:
             result = get_submission_result(session, files, env, solution, dataset)
         except SubmissionResultError as e:
-            eprint(colorSettings.colored(f"Skipping {name}: {e}", "yellow"))
+            eprint(color_settings.colored(f"Skipping {name}: {e}", "yellow"))
             success = False
             continue
 
@@ -116,7 +116,7 @@ def check_results(session: Session, env: Env, dataset: Dataset) -> None:
             if not result.scored():
                 raise SubmissionResultError("This submission has not been scored yet")
         except SubmissionResultError as e:
-            print(colorSettings.colored(f"Skipping {name}: {e}", "yellow"))
+            print(color_settings.colored(f"Skipping {name}: {e}", "yellow"))
             success = False
             continue
 
@@ -135,7 +135,7 @@ def check_results(session: Session, env: Env, dataset: Dataset) -> None:
 
         if score_missed_target is not None:
             message += f" (should be {score_missed_target})"
-            message = colorSettings.colored(message, "red")
+            message = color_settings.colored(message, "red")
             success = False
 
         print(message)
@@ -145,7 +145,7 @@ def check_results(session: Session, env: Env, dataset: Dataset) -> None:
 
         if fractions is None or len(fractions) != len(subtasks):
             message = "The task seems to use an unsupported score type, skipping checking subtasks"
-            print(tab(colorSettings.colored(message, "red")))
+            print(tab(color_settings.colored(message, "red")))
 
             success = False
             continue
@@ -179,7 +179,7 @@ def check_results(session: Session, env: Env, dataset: Dataset) -> None:
 
             if not correct:
                 message += f" (should be {target_name})"
-                message = colorSettings.colored(message, "red")
+                message = color_settings.colored(message, "red")
                 success = False
 
             print(tab(message))

--- a/pisek/cms/submission.py
+++ b/pisek/cms/submission.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 
 from pisek.env.env import Env
 from pisek.config.task_config import SolutionSection
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.utils.paths import TaskPath
 from pisek.utils.text import eprint
 
@@ -147,7 +147,7 @@ def resolve_solution(
     sources = solution.run.build.sources
     if len(sources) != 1:
         eprint(
-            colorSettings.colored(
+            color_settings.colored(
                 "For CMS import there must be exactly one source:\n  "
                 + " ".join(map(lambda p: p.col(env), sources)),
                 "yellow",
@@ -170,7 +170,7 @@ def resolve_solution(
                 return file_path, language
 
     eprint(
-        colorSettings.colored(
+        color_settings.colored(
             f"Skipping {source}, as it isn't available in any enabled language",
             "yellow",
         )

--- a/pisek/config/update_config.py
+++ b/pisek/config/update_config.py
@@ -19,7 +19,7 @@ import re
 
 from pisek.user_errors import TaskConfigError
 from pisek.utils.text import eprint
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.config.config_types import ProgramRole
 
 
@@ -305,7 +305,7 @@ NEWEST_VERSION = "v3"
 def update_config(config: ConfigParser, task_path: str, infos: bool = True) -> None:
     def inform(msg: str):
         if infos:
-            eprint(colorSettings.colored(msg, "yellow"))
+            eprint(color_settings.colored(msg, "yellow"))
 
     version = config.get("task", "version", fallback="v1")
     if version == NEWEST_VERSION:

--- a/pisek/env/env.py
+++ b/pisek/env/env.py
@@ -19,7 +19,7 @@ import os
 from pydantic import Field
 from typing import Optional
 
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.env.base_env import BaseEnv
 from pisek.config.config_hierarchy import DEFAULT_CONFIG_FILENAME
 from pisek.config.task_config import load_config, TaskConfig
@@ -130,4 +130,4 @@ class Env(BaseEnv):
 
     def colored(self, msg: str, color: str) -> str:
         self.no_colors  # Caching
-        return colorSettings.colored(msg, color)
+        return color_settings.colored(msg, color)

--- a/pisek/init.py
+++ b/pisek/init.py
@@ -6,7 +6,7 @@ import shutil
 from typing import Callable, NoReturn, Sequence
 
 from pisek.user_errors import InvalidArgument, InvalidOperation
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.utils.user_input import input_string, input_choice
 from pisek.config.config_types import (
     TaskType,
@@ -52,7 +52,7 @@ def touch(path: str) -> None:
 
 
 def recommended() -> str:
-    return " (" + colorSettings.colored("recommended", "green") + ")"
+    return " (" + color_settings.colored("recommended", "green") + ")"
 
 
 def invalid_config_name(config_filename: str) -> NoReturn:

--- a/pisek/jobs/cache.py
+++ b/pisek/jobs/cache.py
@@ -22,7 +22,7 @@ import pickle
 
 from pisek.version import __version__
 from pisek.utils.text import eprint
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.utils.paths import INTERNALS_DIR
 
 
@@ -87,7 +87,7 @@ class Cache:
         if not all(cache_existence):
             if any(cache_existence):
                 eprint(
-                    colorSettings.colored(
+                    color_settings.colored(
                         "Incomplete cache found. Starting from scratch...",
                         "yellow",
                     )
@@ -99,7 +99,7 @@ class Cache:
 
         if version != __version__:
             eprint(
-                colorSettings.colored(
+                color_settings.colored(
                     "Different version of cache found. Starting from scratch...",
                     "yellow",
                 )

--- a/pisek/task_jobs/solution/solution_manager.py
+++ b/pisek/task_jobs/solution/solution_manager.py
@@ -20,7 +20,7 @@ from typing import Any, Optional
 
 from pisek.utils.text import pad, tab
 from pisek.utils.terminal import right_aligned_text
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.utils.paths import IInputPath
 
 from pisek.jobs.jobs import State, Job, PipelineItemFailure
@@ -414,8 +414,8 @@ class TestJobGroup(TaskHelper):
         right_bracket = "]"
         if self.definitive():
             color = self.verdict.color
-            left_bracket = colorSettings.colored(left_bracket, color)
-            right_bracket = colorSettings.colored(right_bracket, color)
+            left_bracket = color_settings.colored(left_bracket, color)
+            right_bracket = color_settings.colored(right_bracket, color)
 
         return (
             left_bracket
@@ -483,7 +483,7 @@ class TestJobGroup(TaskHelper):
 
         for job in self.new_jobs:
             if job.result is not None:
-                points = colorSettings.colored(
+                points = color_settings.colored(
                     f"({self._format_points(job.result.points(self._env, self.test.points))})",
                     job.result.verdict.color,
                 )

--- a/pisek/task_jobs/solution/solution_result.py
+++ b/pisek/task_jobs/solution/solution_result.py
@@ -21,7 +21,7 @@ from enum import auto, Enum
 from functools import partial, cache, cached_property
 from typing import Callable, Optional, TYPE_CHECKING
 
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.config.config_types import TestPoints
 from pisek.task_jobs.run_result import RunResult
 
@@ -58,7 +58,7 @@ class Verdict(Enum):
             Verdict.error: "!",
             Verdict.normalization_fail: "N",
         }[self]
-        return colorSettings.colored(mark, self.color)
+        return color_settings.colored(mark, self.color)
 
     @cached_property
     def color(self) -> str:

--- a/pisek/utils/colors.py
+++ b/pisek/utils/colors.py
@@ -34,4 +34,4 @@ class __ColorSettings:
         return self._colored(Back, msg, color)
 
 
-colorSettings = __ColorSettings()
+color_settings = __ColorSettings()

--- a/pisek/utils/pipeline_tools.py
+++ b/pisek/utils/pipeline_tools.py
@@ -28,7 +28,7 @@ from pisek.utils.util import clean_non_relevant_files, ChangedCWD
 from pisek.utils.text import eprint
 from pisek.utils.terminal import separator_text
 from pisek.utils.paths import INTERNALS_DIR
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.env.env import Env
 from pisek.config.task_config import load_config
 from pisek.jobs.cache import Cache
@@ -51,7 +51,7 @@ def run_pipeline(
 ) -> None:
     with ChangedCWD(path):
         env = Env.load(**env_args)
-        colorSettings.set_state(not env.no_colors)
+        color_settings.set_state(not env.no_colors)
 
         cache = None
         if not disable_cache:
@@ -64,7 +64,7 @@ def run_pipeline(
                 if i != 0:
                     print()
                 print(
-                    colorSettings.colored(
+                    color_settings.colored(
                         separator_text(f"Run {i+1}/{env.repeat}"), "cyan"
                     )
                 )

--- a/pisek/utils/text.py
+++ b/pisek/utils/text.py
@@ -17,7 +17,7 @@
 import sys
 from typing import NoReturn
 
-from pisek.utils.colors import colorSettings, remove_colors
+from pisek.utils.colors import color_settings, remove_colors
 
 
 def tab(text: str, tab_str: str = "  ") -> str:
@@ -38,7 +38,7 @@ def eprint(msg, *args, **kwargs) -> None:
 
 
 def fatal_user_error(msg, *args, **kwargs) -> NoReturn:
-    eprint(colorSettings.colored(msg, "red"), *args, **kwargs)
+    eprint(color_settings.colored(msg, "red"), *args, **kwargs)
     exit(2)
 
 
@@ -46,4 +46,4 @@ def warn(msg: str, err: type, strict: bool = False) -> None:
     """Warn if strict is False, otherwise raise error."""
     if strict:
         raise err(msg)
-    eprint(colorSettings.colored(msg, "yellow"))
+    eprint(color_settings.colored(msg, "yellow"))

--- a/pisek/utils/user_input.py
+++ b/pisek/utils/user_input.py
@@ -2,7 +2,7 @@ from colorama import Cursor
 from readchar import readkey, key
 from typing import Sequence, TypeVar
 
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 
 T = TypeVar("T")
 
@@ -27,8 +27,10 @@ def input_choice(message: str, choices: Sequence[tuple[T, str]], no_jumps: bool)
         for i, (_, text) in enumerate(choices):
             full_text = f" {i+1}. {text}"
             if selected == i:
-                selector = colorSettings.colored(">", "cyan")
-                print(colorSettings.colored_back(selector + full_text, "lightblack_ex"))
+                selector = color_settings.colored(">", "cyan")
+                print(
+                    color_settings.colored_back(selector + full_text, "lightblack_ex")
+                )
             else:
                 print(" " + full_text)
 

--- a/pisek/visualize.py
+++ b/pisek/visualize.py
@@ -20,7 +20,7 @@ from typing import Any, Optional
 
 from pisek.user_errors import MissingFile
 from pisek.utils.text import pad, tab, eprint
-from pisek.utils.colors import colorSettings
+from pisek.utils.colors import color_settings
 from pisek.utils.terminal import terminal_width
 from pisek.config.config_types import TestPoints
 from pisek.config.task_config import load_config, TaskConfig
@@ -77,10 +77,10 @@ class LoggedResult:
             else:
                 color = "green"
 
-            full_bar = colorSettings.colored("━", color)
+            full_bar = color_settings.colored("━", color)
 
             return (
-                f"[{full_bar*bounded}{('━' if colorSettings.colors_on else ' ')*(segments-bounded)}|"
+                f"[{full_bar*bounded}{('━' if color_settings.colors_on else ' ')*(segments-bounded)}|"
                 f"{full_bar*overflown}{' '*(overflown_max_length - overflown)}{'⋯⋯' if cut else '  '}"
             )
 
@@ -301,7 +301,7 @@ def visualize(
                 max_test_length, max(map(lambda r: len(r.test), results[sol].get_all()))
             )
         except MissingSolution as err:
-            eprint(colorSettings.colored(str(err), "yellow"))
+            eprint(color_settings.colored(str(err), "yellow"))
 
     wrong_solutions = {}
     for sol, sol_res in results.items():
@@ -309,7 +309,7 @@ def visualize(
             sol_err = sol_res.check_points()
             err_msg = ""
             if sol_err is not None:
-                err_msg = colorSettings.colored(f" should get {sol_err}", "red")
+                err_msg = color_settings.colored(f" should get {sol_err}", "red")
                 wrong_solutions[sol] = True
             print(f"{sol}{err_msg}")
 
@@ -317,7 +317,9 @@ def visualize(
                 test_err = sol_res.check_test(num)
                 err_msg = ""
                 if test_err is not None:
-                    err_msg = colorSettings.colored(f" should result {test_err}", "red")
+                    err_msg = color_settings.colored(
+                        f" should result {test_err}", "red"
+                    )
                     wrong_solutions[sol] = True
 
                 print(tab(f"{config.test_sections[num].name}{err_msg}"))
@@ -330,7 +332,9 @@ def visualize(
             sol_errs = sol_res.check_all()
             err_msg = ""
             if sol_errs:
-                err_msg = colorSettings.colored(f" should {', '.join(sol_errs)}", "red")
+                err_msg = color_settings.colored(
+                    f" should {', '.join(sol_errs)}", "red"
+                )
                 wrong_solutions[sol] = True
             print(f"{sol}{err_msg}")
 
@@ -340,7 +344,7 @@ def visualize(
     print()
     if wrong_solutions:
         print(
-            colorSettings.colored(
+            color_settings.colored(
                 f"Solutions {', '.join(wrong_solutions.keys())} should result differently.",
                 "red",
             )
@@ -358,4 +362,4 @@ def visualize(
         limit_msg = f"Valid time limit between {min_possible:.2f}, {max_possible:.2f}."
     else:
         limit_msg = "No valid time limit found."
-    print(colorSettings.colored(limit_msg, "cyan"))
+    print(color_settings.colored(limit_msg, "cyan"))


### PR DESCRIPTION
# Summary:

We change the Pascal-cased instance `ColorSettings` to snake-case `color_settings`.


# Fixes:

#575 

# Test Plan

- [x] Run the `tests` workflow as a sanity check.

<img width="1493" height="312" alt="image" src="https://github.com/user-attachments/assets/7522e76d-d987-49f6-a99e-b36108612b1e" />

# References:

- https://peps.python.org/pep-0008/#function-and-variable-names
- https://www.conventionalcommits.org/en/v1.0.0/