### PR TITLE
fix(config): Don't show redundant dot in error message

### DIFF
--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -278,7 +278,7 @@ class TaskConfig(BaseEnv):
                 if decimal_digits(d) > self.task.score_precision:
                     raise PydanticCustomError(
                         "low_score_precision",
-                        f"Score precision exceeds the task's configured score precision.",
+                        f"Score precision exceeds the task's configured score precision",
                         {"[task] score_precision": self.task.score_precision, name: d},
                     )
 


### PR DESCRIPTION
```
In global config:
  Score precision exceeds the task's configured score precision.:
    [task] score_precision=0
    [test01] points=0.5
```