### PR TITLE
fix(program): Don't enforce process limit when it's > 1

### DIFF
--- a/pisek/task_jobs/program.py
+++ b/pisek/task_jobs/program.py
@@ -54,7 +54,9 @@ class ProgramPoolItem:
         minibox_args.append(f"--time={self.time_limit}")
         minibox_args.append(f"--wall-time={self.clock_limit}")
         minibox_args.append(f"--mem={self.mem_limit*1024}")
-        minibox_args.append(f"--processes={self.process_limit}")
+        # Minibox doesn't support limits for multiple processes (#613)
+        if self.process_limit != 1:
+            minibox_args.append(f"--processes=0")
 
         for std in ("stdin", "stdout", "stderr"):
             attr = getattr(self, std)


### PR DESCRIPTION
Minibox restricts the binary to one process, if process_limit is not zero. So now the behaviour should be equivalent to the docs.