### PR TITLE
fix(config): Remove old [solutions] keys from config description

### DIFF
--- a/pisek/config/config-description
+++ b/pisek/config/config-description
@@ -96,13 +96,10 @@ tests=
 [solutions]
 run=
 primary=
+tests=
 points=
 points_min=
 points_max=
-tests=
-subtasks=
-stub=
-headers=
 
 # -------------- runs --------------
 


### PR DESCRIPTION
Fixes #630 