### PR TITLE
feat(config): Add limits on the total size of all limits/outputs

### DIFF
--- a/docs/config-v3-documentation.md
+++ b/docs/config-v3-documentation.md
@@ -916,6 +916,20 @@ Maximum input size [MB]. (`0` for unlimited.)
 
 Maximum output size [MB]. (`0` for unlimited.)
 
+### total_inputs_max_size
+<!-- md:version 2.4.0 -->
+<!-- md:type decimal | 'unlimited' -->
+<!-- md:default 1024 -->
+
+Limit on the total size of all inputs [MB].
+
+### total_outputs_max_size
+<!-- md:version 2.4.0 -->
+<!-- md:type decimal | 'unlimited' -->
+<!-- md:default 1024 -->
+
+Limit on the total size of all outputs [MB].
+
 ## [cms]
 Settings related to the CMS importer. See [CMS docs](https://cms.readthedocs.io/en/latest/) for details.
 

--- a/pisek/config/config-description
+++ b/pisek/config/config-description
@@ -428,6 +428,8 @@ extra_sources_py=
 [limits]
 input_max_size=
 output_max_size=
+total_inputs_max_size=
+total_outputs_max_size=
 
 [cms]
 name=

--- a/pisek/config/config_types.py
+++ b/pisek/config/config_types.py
@@ -13,8 +13,11 @@
 from decimal import Decimal, InvalidOperation
 from enum import auto, StrEnum
 from pydantic_core import PydanticCustomError
-from pydantic import BeforeValidator
+from pydantic import BeforeValidator, Field
 from typing import Annotated, Literal
+
+PositiveDecimal = Annotated[Decimal, Field(gt=0)]
+PositiveDecimalLimit = PositiveDecimal | Literal["unlimited"]
 
 
 class TaskType(StrEnum):

--- a/pisek/config/global-defaults
+++ b/pisek/config/global-defaults
@@ -79,6 +79,8 @@ extra_sources_py=
 [limits]
 input_max_size=50
 output_max_size=10
+total_inputs_max_size=1024
+total_outputs_max_size=1024
 
 [cms]
 name=

--- a/pisek/config/task_config.py
+++ b/pisek/config/task_config.py
@@ -52,6 +52,7 @@ from pisek.config.config_types import (
     BuildStrategyName,
     CMSFeedbackLevel,
     CMSScoreMode,
+    PositiveDecimalLimit,
 )
 from pisek.env.context import init_context
 from pisek.task_jobs.solution.solution_result import TEST_SPEC
@@ -948,6 +949,8 @@ class LimitsSection(BaseEnv):
 
     input_max_size: Decimal
     output_max_size: Decimal
+    total_inputs_max_size: PositiveDecimalLimit
+    total_outputs_max_size: PositiveDecimalLimit
 
     @classmethod
     def load_dict(cls, configs: ConfigHierarchy) -> ConfigValuesDict:

--- a/pisek/task_jobs/completeness_check.py
+++ b/pisek/task_jobs/completeness_check.py
@@ -11,18 +11,21 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import filecmp
+import os
 
 from pisek.utils.paths import TaskPath
 from pisek.env.env import TestingTarget
 from pisek.config.config_types import JudgeType, TaskType
 from pisek.task_jobs.solution.solution_result import Verdict
-from pisek.jobs.jobs import Job
+from pisek.jobs.jobs import Job, PipelineItemFailure
 from pisek.task_jobs.task_manager import (
     TaskJobManager,
     FUZZ_MAN_CODE,
     SOLUTION_MAN_CODE,
 )
 from pisek.task_jobs.manager_results import SolutionManagerResult, FuzzingManagerResult
+
+MB = 1024 * 1024
 
 
 class CompletenessCheck(TaskJobManager):
@@ -117,9 +120,40 @@ class CompletenessCheck(TaskJobManager):
                     if self._env.verbosity <= 0:
                         return
 
+    def _check_total_inputs_size(self) -> None:
+        tr = self.prerequisite_result(
+            f"{SOLUTION_MAN_CODE}{self._env.config.primary_solution}",
+            SolutionManagerResult,
+        ).testcase_results
+
+        total = sum(os.path.getsize(inp.path) for inp in tr)
+        limit = self._env.config.limits.total_inputs_max_size
+        if limit != "unlimited" and total > limit * MB:
+            raise PipelineItemFailure(
+                f"Total input size is bigger than {limit}MB: {(total+MB-1)//MB}MB"
+            )
+
+    def _check_total_outputs_size(self) -> None:
+        if self._env.config.task.task_type == TaskType.interactive:
+            return
+
+        tr = self.prerequisite_result(
+            f"{SOLUTION_MAN_CODE}{self._env.config.primary_solution}",
+            SolutionManagerResult,
+        ).testcase_results
+
+        total = sum(os.path.getsize(inp.to_output().path) for inp in tr)
+        limit = self._env.config.limits.total_outputs_max_size
+        if limit != "unlimited" and total > limit * MB:
+            raise PipelineItemFailure(
+                f"Total output size is bigger than {limit}MB: {(total+MB-1)//MB}MB"
+            )
+
     def _evaluate(self) -> None:
         assert self._env.target == TestingTarget.all
 
         self._check_cms_judge()
         self._check_different_outputs()
         self._check_dedicated_solutions()
+        self._check_total_inputs_size()
+        self._check_total_outputs_size()


### PR DESCRIPTION
Fixes #635. Fixes #636.
Add limits on the total size of all limits/outputs and add docs.